### PR TITLE
Corrected urls (default to HTTPS repo access)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,50 +26,50 @@
     path = libs/stream
     url = https://github.com/nilfoundation/stream.git
 [submodule "libs/passhash"]
-	path = libs/passhash
-	url = https://github.com/nilfoundation/passhash.git
+    path = libs/passhash
+    url = https://github.com/nilfoundation/passhash.git
 [submodule "libs/pbkdf"]
-	path = libs/pbkdf
-	url = https://github.com/nilfoundation/pbkdf.git
+    path = libs/pbkdf
+    url = https://github.com/nilfoundation/pbkdf.git
 [submodule "libs/algebra"]
-	path = libs/algebra
-	url = git@github.com:nilfoundation/algebra.git
+    path = libs/algebra
+    url = https://github.com/nilfoundation/algebra.git
 [submodule "libs/math"]
-	path = libs/math
-	url = git@github.com:nilfoundation/crypto3-math.git
+    path = libs/math
+    url = https://github.com/nilfoundation/crypto3-math.git
 [submodule "libs/pkpad"]
-	path = libs/pkpad
-	url = git@github.com:nilfoundation/pkpad.git
+    path = libs/pkpad
+    url = https://github.com/nilfoundation/pkpad.git
 [submodule "libs/pubkey"]
-	path = libs/pubkey
-	url = git@github.com:nilfoundation/pubkey.git
+    path = libs/pubkey
+    url = https://github.com/nilfoundation/pubkey.git
 [submodule "libs/pkmodes"]
-	path = libs/pkmodes
-	url = git@github.com:nilfoundation/crypto3-pkmodes.git
+    path = libs/pkmodes
+    url = https://github.com/nilfoundation/crypto3-pkmodes.git
 [submodule "libs/zk"]
-	path = libs/zk
-	url = git@github.com:nilfoundation/crypto3-zk.git
+    path = libs/zk
+    url = https://github.com/nilfoundation/crypto3-zk.git
 [submodule "libs/random"]
-	path = libs/random
-	url = git@github.com:nilfoundation/random.git
+    path = libs/random
+    url = https://github.com/nilfoundation/random.git
 [submodule "libs/multiprecision"]
-	path = libs/multiprecision
-	url = git@github.com:nilfoundation/crypto3-multiprecision.git
+    path = libs/multiprecision
+    url = https://github.com/nilfoundation/crypto3-multiprecision.git
 [submodule "libs/blueprint"]
-	path = libs/blueprint
-	url = git@github.com:nilfoundation/crypto3-blueprint.git
+    path = libs/blueprint
+    url = https://github.com/nilfoundation/crypto3-blueprint.git
 [submodule "libs/marshalling/core"]
-	path = libs/marshalling/core
-	url = git@github.com:NilFoundation/marshalling.git
+    path = libs/marshalling/core
+    url = https://github.com/NilFoundation/marshalling.git
 [submodule "libs/marshalling/multiprecision"]
-	path = libs/marshalling/multiprecision
-	url = git@github.com:NilFoundation/crypto3-multiprecision-marshalling.git
+    path = libs/marshalling/multiprecision
+    url = https://github.com/NilFoundation/crypto3-multiprecision-marshalling.git
 [submodule "libs/marshalling/algebra"]
-	path = libs/marshalling/algebra
-	url = git@github.com:NilFoundation/crypto3-algebra-marshalling.git
+    path = libs/marshalling/algebra
+    url = https://github.com/NilFoundation/crypto3-algebra-marshalling.git
 [submodule "libs/marshalling/zk"]
-	path = libs/marshalling/zk
-	url = git@github.com:NilFoundation/crypto3-zk-marshalling.git
+    path = libs/marshalling/zk
+    url = https://github.com/NilFoundation/crypto3-zk-marshalling.git
 [submodule "libs/containers"]
-	path = libs/containers
-	url = git@github.com:nilfoundation/crypto3-containers.git
+    path = libs/containers
+    url = https://github.com/nilfoundation/crypto3-containers.git


### PR DESCRIPTION
this still requires applying the `git submodule sync` command before `git submodule update`

somebody from Nil Foundation should push the result of the submodule sync, and update README.md to include instructions:

`% git clone --recurse-submodules https://github.com/NilFoundation/crypto3`

When the above command fails, replace .gitmodules file with the version in my commit https://github.com/NilFoundation/crypto3/pull/21/commits/4e067c00330cfc2dd570381b8d8b4dddeb7482f8 then try:

```
% git submodule sync
Synchronizing submodule url for 'cmake/modules'
Synchronizing submodule url for 'libs/algebra'
Synchronizing submodule url for 'libs/block'
Synchronizing submodule url for 'libs/blueprint'
Synchronizing submodule url for 'libs/codec'
Synchronizing submodule url for 'libs/containers'
Synchronizing submodule url for 'libs/hash'
Synchronizing submodule url for 'libs/kdf'
Synchronizing submodule url for 'libs/mac'
Synchronizing submodule url for 'libs/marshalling/algebra'
Synchronizing submodule url for 'libs/marshalling/core'
Synchronizing submodule url for 'libs/marshalling/multiprecision'
Synchronizing submodule url for 'libs/marshalling/zk'
Synchronizing submodule url for 'libs/math'
Synchronizing submodule url for 'libs/modes'
Synchronizing submodule url for 'libs/multiprecision'
Synchronizing submodule url for 'libs/passhash'
Synchronizing submodule url for 'libs/pbkdf'
Synchronizing submodule url for 'libs/pkmodes'
Synchronizing submodule url for 'libs/pkpad'
Synchronizing submodule url for 'libs/pubkey'
Synchronizing submodule url for 'libs/random'
Synchronizing submodule url for 'libs/stream'
Synchronizing submodule url for 'libs/vdf'
Synchronizing submodule url for 'libs/zk'
```

Followed by:

`% git submodule update`

Producing the intended git clone of each submodule followed by checkout of the branch intended:

```
Submodule path 'libs/algebra': checked out 'f8fcef6aab3495de5cc7a0075f6335c4268542d9'
Submodule path 'libs/blueprint': checked out '5a8cd75253f4b7059139e5b24e31dc993c19e32f'
Submodule path 'libs/containers': checked out 'c948f9af5a751e927fe8c8f7de8267aee9867375'
Submodule path 'libs/hash': checked out '2a1803ae82fb64a61fd351a8a3b0221cec5b004d'
Submodule path 'libs/kdf': checked out 'f7839580991b825e3857c0ec3fb7832b2cb9ad0c'
Submodule path 'libs/mac': checked out '9442b439a68d2b41ca2382f07dc066a5be9f5d1d'
Submodule path 'libs/marshalling/algebra': checked out '28378a40e05934524058354f739d3092ff4708f9'
Submodule path 'libs/marshalling/core': checked out 'a18c6ea6e4e24ed999c7721fa0b5ce366756f8a7'
Submodule path 'libs/marshalling/multiprecision': checked out '533bcb385df5704b7280a77785eb6b8e30d8c4c4'
Submodule path 'libs/marshalling/zk': checked out '4946ee7c22c9fd56cd196b9adb351c948522bf2d'
Submodule path 'libs/math': checked out 'ea546c250eb79753a2cbcfedd3fcc7ab30e8afb8'
Submodule path 'libs/modes': checked out 'f21ae3185dcd37ccef31523e40ec0203c201da36'
Submodule path 'libs/multiprecision': checked out '23319fac6a5eeca444886e558421e188cf578eff'
Submodule path 'libs/passhash': checked out '3466d45bb2832d1e8624a4d6d554726b534079ab'
Submodule path 'libs/pbkdf': checked out 'e88fc336a1ae79209ce202c56f58ed9bd2a4869a'
Submodule path 'libs/pkmodes': checked out '0dc8defe1a2199cb798df943b8665ec1a53c295b'
Submodule path 'libs/pkpad': checked out 'd190766ec2e4f899f9b178cb8e89f3d3378252bf'
Submodule path 'libs/pubkey': checked out '2ffb35f0d4cd2f31102dba1d7513fa9a90b3a5a1'
Submodule path 'libs/random': checked out '6d8b5672ed1b262d64fef9770096ca7b9c9580aa'
Submodule path 'libs/stream': checked out '104802b3f0f1097174acc457f93a34ea4e875ca2'
Submodule path 'libs/vdf': checked out '69c18131b42429e58788a7854b2deb7def217364'
Submodule path 'libs/zk': checked out 'f8aa95692dbbb41a49b56472a5299f9debfa79ef'
```
