### PR TITLE
Add workaround config file to import crypto3 package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,3 +67,21 @@ add_subdirectories("${CMAKE_CURRENT_LIST_DIR}/libs/marshalling")
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/docs/doxygen/${CMAKE_WORKSPACE_NAME}.doxyfile.in
     ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_WORKSPACE_NAME}.doxyfile @ONLY)
+
+# Configure package file to be able to import crypto3 headers
+# TODO: remove it after resolving cyclical dependencies in crypto3 modules
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+set(CONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/crypto3)
+
+configure_package_config_file(
+    cmake/Config.cmake.in
+    crypto3Config.cmake
+    INSTALL_DESTINATION ${CONFIG_DIR}
+)
+
+install(
+    FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/crypto3Config.cmake
+    DESTINATION ${CONFIG_DIR}
+)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,16 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Boost COMPONENTS REQUIRED
+                    container json filesystem log log_setup program_options thread system unit_test_framework)
+
+# Protect against multiple inclusion
+if (TARGET crypto3::all)
+  return()
+endif()
+
+add_library(crypto3::all INTERFACE IMPORTED)
+
+set_target_properties(crypto3::all PROPERTIES
+                        INTERFACE_INCLUDE_DIRECTORIES "@CMAKE_INSTALL_FULL_INCLUDEDIR@"
+                        INTERFACE_LINK_LIBRARIES ${Boost_LIBRARIES})


### PR DESCRIPTION
This pull request brings separate package config file to be able to import all `crypto3` headers. It is a workaround, because we already have config files for all of the `crypto3` modules. But the usage of them is impossible for now because of the cyclical dependencies in modules.

**Pros:**
* With these changes we are able to use `crypto3` in other repositories without making it a submodule:
```cmake
find_package(crypto3 REQUIRED)
target_link_libraries(${PROJECT_NAME} crypto3::all)
```
**Cons:**
* Introduced target `crypto3::all` that does not exist in main repository (to avoid workaround support for all the modules)
* Dependencies are hardcoded, so they will require a manual update in case of their change in the modules.