### PR TITLE
Fix equality checks for modular numbers in multiprecision.

### DIFF
--- a/libs/algebra/test/bench_test/bench_fields.cpp
+++ b/libs/algebra/test/bench_test/bench_fields.cpp
@@ -115,6 +115,18 @@ void run_perf_test() {
         std::chrono::high_resolution_clock::now() - start);
     std::cout << "Inversion time: " << std::fixed << std::setprecision(3)
         << elapsed.count() / (SAMPLES / 1000) << " ns" << std::endl;
+
+    start = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < SAMPLES; ++i) {
+        int index = i % points1.size();
+        BOOST_CHECK_EQUAL(points1[index], points1[index]);
+    }
+
+    elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::high_resolution_clock::now() - start);
+    std::cout << "Equality check time: " << std::fixed << std::setprecision(3)
+        << elapsed.count() / SAMPLES << " ns" << std::endl;
 }
 
 BOOST_AUTO_TEST_CASE(field_operation_perf_test_pallas) {

--- a/libs/math/test/polynomial_dfs.cpp
+++ b/libs/math/test/polynomial_dfs.cpp
@@ -1385,4 +1385,27 @@ BOOST_AUTO_TEST_CASE(polynomial_dfs_resize_perf_test, *boost::unit_test::disable
     std::cout << "Resize time: " << duration.count() << " microseconds." << std::endl;
 }
 
+BOOST_AUTO_TEST_CASE(polynomial_dfs_equality_check_perf_test, *boost::unit_test::disabled()) {
+    size_t size = 131072 * 16;
+
+    polynomial_dfs<typename FieldType::value_type> poly = {
+        size / 128, size, nil::crypto3::algebra::random_element<FieldType>()};
+
+    std::vector<polynomial_dfs<typename FieldType::value_type>> poly4(64, poly);
+
+    auto start = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < poly4.size(); ++i) {
+        BOOST_CHECK(poly4[i] == poly);
+    }
+
+    // Record the end time
+    auto end = std::chrono::high_resolution_clock::now();
+
+    // Calculate the duration
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+    std::cout << "Equality check time: " << duration.count() << " microseconds." << std::endl;
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/multiprecision/include/nil/crypto3/multiprecision/modular/modular_adaptor_fixed.hpp
+++ b/libs/multiprecision/include/nil/crypto3/multiprecision/modular/modular_adaptor_fixed.hpp
@@ -370,6 +370,22 @@ namespace boost {
             static const expression_template_option value = boost::multiprecision::et_off;
         };
 
+        // We need to specialize this function, because default boost implementation is "return a.compare(b) == 0;", which is waay slower.    
+        template<unsigned Bits, typename StorageType, expression_template_option ExpressionTemplates>
+            inline BOOST_MP_CXX14_CONSTEXPR bool operator==(
+                const number<backends::modular_adaptor<backends::cpp_int_modular_backend<Bits>, StorageType>, ExpressionTemplates>& a,
+                const number<backends::modular_adaptor<backends::cpp_int_modular_backend<Bits>, StorageType>, ExpressionTemplates>& b) {
+            return a.backend().compare_eq(b.backend());
+        }
+
+        // We need to specialize this function, because default boost implementation is "return a.compare(b) == 0;", which is waay slower.    
+        template<unsigned Bits, typename StorageType, expression_template_option ExpressionTemplates>
+            inline BOOST_MP_CXX14_CONSTEXPR bool operator!=(
+                const number<backends::modular_adaptor<backends::cpp_int_modular_backend<Bits>, StorageType>, ExpressionTemplates>& a,
+                const number<backends::modular_adaptor<backends::cpp_int_modular_backend<Bits>, StorageType>, ExpressionTemplates>& b) {
+            return !a.backend().compare_eq(b.backend());
+        }
+
     }   // namespace multiprecision
 }   // namespace boost
 


### PR DESCRIPTION
Fixed equality checks for modular numbers in multiprecision. It was 60x slower, due to some problem inside boost.
Also added some new benchmarks on equality operation for the future.