### PR TITLE
Move crypto3 derivation into a separate file, and clean it up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 find_package(CM)
 include(CMConfig)
 include(CMSetupVersion)
-
 cm_workspace(crypto3)
 cm_setup_version(VERSION 0.3.0 PREFIX ${CMAKE_WORKSPACE_NAME})
 

--- a/crypto3.nix
+++ b/crypto3.nix
@@ -1,0 +1,43 @@
+{ lib,
+  stdenv,
+  src_repo,
+  ninja,
+  pkg-config,
+  cmake,
+  boost183,
+  # We'll use boost183 by default, but you can override it
+  boost_lib ? boost183,
+  cmake_modules,
+  enableDebugging,
+  enableDebug ? false
+  }:
+let
+  inherit (lib) optional;
+in stdenv.mkDerivation {
+  name = "Crypto3";
+
+  src = src_repo;
+
+  nativeBuildInputs = [ cmake ninja pkg-config ];
+
+  # enableDebugging will keep debug symbols in boost
+  propagatedBuildInputs = [ (if enableDebug then (enableDebugging boost_lib) else boost_lib) ];
+
+  buildInputs = [cmake_modules];
+
+  cmakeFlags =
+    [ "-B build" "-G Ninja" "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}" ];
+
+  dontBuild = true; # nothing to build, header-only lib
+
+  doCheck = false; # tests are inside crypto3-tests derivation
+
+  installPhase = ''
+    cmake --build build --target install
+  '';
+
+  shellHook = ''
+    PS1="\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "
+    echo "Welcome to Crypto3 development environment!"
+  '';
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,7 +20,9 @@
     },
     "nix-3rdparty": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -56,6 +58,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nix-3rdparty": "nix-3rdparty",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,249 +1,179 @@
 {
-  description = "Nix flake for Crypto3 header-only C++ library by =nil; Foundation";
+  description =
+    "Nix flake for Crypto3 header-only C++ library by Nil; Foundation";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
-    nix-3rdparty = {
-      url = "github:NilFoundation/nix-3rdparty";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-      };
-    };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    nix-3rdparty.url = "github:NilFoundation/nix-3rdparty";
+    nix-3rdparty.inputs.nixpkgs.follows = "nixpkgs";
+    nix-3rdparty.inputs.flake-utils.follows = "flake-utils";
   };
 
-  outputs = { self
-  , nixpkgs
-  , nix-3rdparty
-  , ... }:
-    let
-      supportedSystems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "aarch64-darwin"
-      ];
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-
-      makeCrypto3Derivation = { system }:
-        let
-          pkgs = import nixpkgs {
-            overlays = [ nix-3rdparty.overlays.${system}.default ];
-            inherit system;
+  outputs = { self, nixpkgs, flake-utils, nix-3rdparty, ... }:
+    (flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ nix-3rdparty.overlays.${system}.default ];
         };
-        in
-        pkgs.stdenv.mkDerivation {
-          name = "Crypto3";
-
-          src = self;
-
-          nativeBuildInputs = with pkgs; [
-            cmake
-            cmake_modules
-            ninja
-            pkg-config
-          ];
-
-          propagatedBuildInputs = with pkgs; [
-            boost183
-          ];
-
-          cmakeFlags = [
-            "-B build"
-            "-G Ninja"
-            "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
-          ];
-
-          dontBuild = true; # nothing to build, header-only lib
-
-          doCheck = false; # tests are inside crypto3-tests derivation
-
-          installPhase = ''
-            cmake --build build --target install
-          '';
-        };
-
-      makeCrypto3Shell = { system }:
-        let
-          pkgs = import nixpkgs {
-            overlays = [ nix-3rdparty.overlays.${system}.default ];
-            inherit system;
-        };
-        in
-        pkgs.mkShell {
-          buildInputs = with pkgs; [
-            cmake
-            cmake_modules
-            ninja
-            clang
-            gcc
-            boost183
-          ];
-
-          shellHook = ''
-            PS1="\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "
-            echo "Welcome to Crypto3 development environment!"
-          '';
-        };
-
-      makeCrypto3Tests = { system }:
-        let
-          pkgs = import nixpkgs {
-            overlays = [ nix-3rdparty.overlays.${system}.default ];
-            inherit system;
-        };
-          isDarwin = builtins.match ".*-darwin" system != null; # Used only to exclude gcc from macOS.
-          testCompilers = [
-            "clang"
-            # TODO: fix gcc linkage on macOS, remove optional condition
-          ] ++ nixpkgs.lib.optional (!isDarwin) "gcc";
-          # We have lots of failing tests. Modules with such tests are kept here. Built as separate targets.
-          brokenModuleToTestsNames = {
-            pubkey = [
-              "pubkey_ecdsa_test"
-              "pubkey_bls_test"
-            ];
-            zk = [
-              "crypto3_zk_commitment_fold_polynomial_test"
-              "crypto3_zk_commitment_fri_test"
-              "crypto3_zk_commitment_lpc_test"
-              "crypto3_zk_systems_plonk_placeholder_placeholder_circuits_test"
-              "crypto3_zk_systems_plonk_placeholder_placeholder_curves_test"
-              "crypto3_zk_systems_plonk_placeholder_placeholder_gate_argument_test"
-              "crypto3_zk_systems_plonk_placeholder_placeholder_goldilocks_test"
-              "crypto3_zk_systems_plonk_placeholder_placeholder_hashes_test"
-              "crypto3_zk_systems_plonk_placeholder_placeholder_kzg_test"
-              "crypto3_zk_systems_plonk_placeholder_placeholder_lookup_argument_test"
-              "crypto3_zk_systems_plonk_placeholder_placeholder_permutation_argument_test"
-              "crypto3_zk_systems_plonk_placeholder_placeholder_quotient_polynomial_chunks_test"
-              # "crypto3_zk_commitment_powers_of_tau_test"
-              "crypto3_zk_commitment_proof_of_knowledge_test"
-              "crypto3_zk_commitment_r1cs_gg_ppzksnark_mpc_test"
-              "crypto3_zk_math_expression_test"
-              "crypto3_zk_systems_plonk_plonk_constraint_test"
-            ];
-            # Everything is built successfully, just can't use regex to distinguish from other marshalling tests
-            # TODO: change prefix to marshalling_core inside module, move to moduleToTestsRegex
-            marshalling-core = [
-              "marshalling_processing_test"
-              "marshalling_interfaces_test"
-              "marshalling_types_test"
-            ];
-            # Ditto
-            marshalling-zk = [
-              "marshalling_fri_commitment_test"
-              "marshalling_lpc_commitment_test"
-              "marshalling_placeholder_common_data_test"
-              "marshalling_placeholder_proof_test"
-              "marshalling_sparse_vector_test"
-              "marshalling_accumulation_vector_test"
-              "marshalling_plonk_constraint_system_test"
-              "marshalling_plonk_assignment_table_test"
-              "marshalling_plonk_gates_test"
-              "marshalling_r1cs_gg_ppzksnark_primary_input_test"
-              "marshalling_r1cs_gg_ppzksnark_proof_test"
-              "marshalling_r1cs_gg_ppzksnark_verification_key_test"
-              "marshalling_merkle_proof_test"
-            ];
-            # Ditto
-            marshalling-algebra = [
-              "marshalling_field_element_test"
-              "marshalling_field_element_non_fixed_size_container_test"
-              "marshalling_curve_element_fixed_size_container_test"
-              "marshalling_curve_element_non_fixed_size_container_test"
-              "marshalling_curve_element_test"
-            ];
-          };
-          # Modules with no failing tests are kept here. Built as `tests-crypto3-<module_name>` targets
-          moduleToTestsRegex = {
-            algebra = "algebra_.*_test";
-            containers = "crypto3_containers_.*_test";
-            hash = "hash_.*_test";
-            math = "math_.*_test";
-            block = "block_.*_test";
-            multiprecision = "multiprecision_.*_test";
-          };
-          makeTestDerivation = { name, compiler, targets ? [ ], buildTargets ? targets, testTargets ? targets }:
-            (makeCrypto3Derivation { inherit system; }).overrideAttrs (oldAttrs: {
-              name = "Crypto3-${name}-tests";
-
-              nativeBuildInputs = oldAttrs.nativeBuildInputs ++ oldAttrs.propagatedBuildInputs ++ [
-                (if compiler == "gcc" then pkgs.gcc else pkgs.clang)
+        makeCrypto3Tests = { system }:
+          let
+            isDarwin = builtins.match ".*-darwin" system
+              != null; # Used only to exclude gcc from macOS.
+            testCompilers = [
+              "clang"
+              # TODO: fix gcc linkage on macOS, remove optional condition
+            ] ++ nixpkgs.lib.optional (!isDarwin) "gcc";
+            # We have lots of failing tests. Modules with such tests are kept here. Built as separate targets.
+            brokenModuleToTestsNames = {
+              pubkey = [ "pubkey_ecdsa_test" "pubkey_bls_test" ];
+              zk = [
+                "crypto3_zk_commitment_fold_polynomial_test"
+                "crypto3_zk_commitment_fri_test"
+                "crypto3_zk_commitment_lpc_test"
+                "crypto3_zk_systems_plonk_placeholder_placeholder_circuits_test"
+                "crypto3_zk_systems_plonk_placeholder_placeholder_curves_test"
+                "crypto3_zk_systems_plonk_placeholder_placeholder_gate_argument_test"
+                "crypto3_zk_systems_plonk_placeholder_placeholder_goldilocks_test"
+                "crypto3_zk_systems_plonk_placeholder_placeholder_hashes_test"
+                "crypto3_zk_systems_plonk_placeholder_placeholder_kzg_test"
+                "crypto3_zk_systems_plonk_placeholder_placeholder_lookup_argument_test"
+                "crypto3_zk_systems_plonk_placeholder_placeholder_permutation_argument_test"
+                "crypto3_zk_systems_plonk_placeholder_placeholder_quotient_polynomial_chunks_test"
+                # "crypto3_zk_commitment_powers_of_tau_test"
+                "crypto3_zk_commitment_proof_of_knowledge_test"
+                "crypto3_zk_commitment_r1cs_gg_ppzksnark_mpc_test"
+                "crypto3_zk_math_expression_test"
+                "crypto3_zk_systems_plonk_plonk_constraint_test"
               ];
-
-              propagatedBuildInputs = [];
-
-              cmakeFlags = [
-                "-G Ninja"
-                "-DCMAKE_CXX_COMPILER=${if compiler == "gcc" then "g++" else "clang++"}"
-                "-DCMAKE_BUILD_TYPE=Release" # TODO: change to Debug after build fix
-                "-DCMAKE_ENABLE_TESTS=TRUE"
+              # Everything is built successfully, just can't use regex to distinguish from other marshalling tests
+              # TODO: change prefix to marshalling_core inside module, move to moduleToTestsRegex
+              marshalling-core = [
+                "marshalling_processing_test"
+                "marshalling_interfaces_test"
+                "marshalling_types_test"
               ];
+              # Ditto
+              marshalling-zk = [
+                "marshalling_fri_commitment_test"
+                "marshalling_lpc_commitment_test"
+                "marshalling_placeholder_common_data_test"
+                "marshalling_placeholder_proof_test"
+                "marshalling_sparse_vector_test"
+                "marshalling_accumulation_vector_test"
+                "marshalling_plonk_constraint_system_test"
+                "marshalling_plonk_assignment_table_test"
+                "marshalling_plonk_gates_test"
+                "marshalling_r1cs_gg_ppzksnark_primary_input_test"
+                "marshalling_r1cs_gg_ppzksnark_proof_test"
+                "marshalling_r1cs_gg_ppzksnark_verification_key_test"
+                "marshalling_merkle_proof_test"
+              ];
+              # Ditto
+              marshalling-algebra = [
+                "marshalling_field_element_test"
+                "marshalling_field_element_non_fixed_size_container_test"
+                "marshalling_curve_element_fixed_size_container_test"
+                "marshalling_curve_element_non_fixed_size_container_test"
+                "marshalling_curve_element_test"
+              ];
+            };
+            # Modules with no failing tests are kept here. Built as `tests-crypto3-<module_name>` targets
+            moduleToTestsRegex = {
+              algebra = "algebra_.*_test";
+              containers = "crypto3_containers_.*_test";
+              hash = "hash_.*_test";
+              math = "math_.*_test";
+              block = "block_.*_test";
+              multiprecision = "multiprecision_.*_test";
+            };
+            makeTestDerivation = { name, compiler, targets ? [ ]
+              , buildTargets ? targets, testTargets ? targets }:
+              (pkgs.callPackage ./crypto3.nix {
+                src_repo = self;
+                enableDebug = true;
+              }).overrideAttrs (oldAttrs: {
+                name = "Crypto3-${name}-tests";
 
-              dontBuild = false;
-              # working dir is already set to build dir
-              buildPhase = ''
-                cmake --build . --parallel $NIX_BUILD_CORES --target ${nixpkgs.lib.concatStringsSep " " buildTargets}
-              '';
+                nativeBuildInputs = oldAttrs.nativeBuildInputs
+                  ++ oldAttrs.propagatedBuildInputs
+                  ++ [ (if compiler == "gcc" then pkgs.gcc else pkgs.clang) ];
 
-              doCheck = true;
-              checkPhase = ''
-                # JUNIT file without explicit file name is generated after the name of the master test suite inside `CMAKE_CURRENT_SOURCE_DIR` (/build/source)
-                export BOOST_TEST_LOGGER=JUNIT:HRF
-                ctest --verbose -j $NIX_BUILD_CORES --output-on-failure -R "${nixpkgs.lib.concatStringsSep "|" (map (target: "^" + target + "$") testTargets)}"
+                propagatedBuildInputs = [ ];
 
-                mkdir -p ${placeholder "out"}/test-logs
-                find .. -type f -name '*_test.xml' -exec cp {} ${placeholder "out"}/test-logs \;
-              '';
+                cmakeFlags = [
+                  "-G Ninja"
+                  "-DCMAKE_CXX_COMPILER=${
+                    if compiler == "gcc" then "g++" else "clang++"
+                  }"
+                  "-DBUILD_TESTS=TRUE" # TODO: remove after https://github.com/NilFoundation/crypto3/issues/146
+                  "-DCMAKE_BUILD_TYPE=Release" # TODO: change to Debug after build fix
+                  "-DCMAKE_ENABLE_TESTS=TRUE"
+                ];
 
-              dontInstall = true;
-            });
-          compilerBrokenModuleTestsNamesPairs = pkgs.lib.cartesianProductOfSets {
-            compiler = testCompilers;
-            module = pkgs.lib.attrNames brokenModuleToTestsNames;
-          };
-          compilerModuleTestsRegexPairs = pkgs.lib.cartesianProductOfSets {
-            compiler = testCompilers;
-            module = pkgs.lib.attrNames moduleToTestsRegex;
-          };
-        in
-        pkgs.lib.listToAttrs (
-          builtins.map
-            (pair: {
-              name = "${pair.module}-${pair.compiler}";
-              value = makeTestDerivation {
-                name = pair.module;
-                compiler = pair.compiler;
-                targets = brokenModuleToTestsNames.${pair.module};
+                dontBuild = false;
+                # working dir is already set to build dir
+                buildPhase = ''
+                  cmake --build . --parallel $NIX_BUILD_CORES --target ${
+                    nixpkgs.lib.concatStringsSep " " buildTargets
+                  }
+                '';
+
+                doCheck = true;
+                checkPhase = ''
+                  # JUNIT file without explicit file name is generated after the name of the master test suite inside `CMAKE_CURRENT_SOURCE_DIR` (/build/source)
+                  export BOOST_TEST_LOGGER=JUNIT:HRF
+                  ctest --verbose -j $NIX_BUILD_CORES --output-on-failure -R "${
+                    nixpkgs.lib.concatStringsSep "|"
+                    (map (target: "^" + target + "$") testTargets)
+                  }"
+
+                  mkdir -p ${placeholder "out"}/test-logs
+                  find .. -type f -name '*_test.xml' -exec cp {} ${
+                    placeholder "out"
+                  }/test-logs \;
+                '';
+
+                dontInstall = true;
+              });
+            compilerBrokenModuleTestsNamesPairs =
+              pkgs.lib.cartesianProductOfSets {
+                compiler = testCompilers;
+                module = pkgs.lib.attrNames brokenModuleToTestsNames;
               };
-            })
-            compilerBrokenModuleTestsNamesPairs
-          ++
-          builtins.map
-            (pair: {
-              name = "${pair.module}-${pair.compiler}";
-              value = makeTestDerivation {
-                name = pair.module;
-                compiler = pair.compiler;
-                buildTargets = [ "tests-crypto3-${pair.module}" ];
-                testTargets = [ moduleToTestsRegex.${pair.module} ];
-              };
-            })
-            compilerModuleTestsRegexPairs
-        );
-    in
-    {
-      packages = forAllSystems (system: {
-        default = makeCrypto3Derivation { inherit system; };
-      });
-      checks = forAllSystems (system:
-        makeCrypto3Tests { inherit system; }
-      );
-      devShells = forAllSystems (system: {
-        default = makeCrypto3Shell { inherit system; };
-      });
-    };
+            compilerModuleTestsRegexPairs = pkgs.lib.cartesianProductOfSets {
+              compiler = testCompilers;
+              module = pkgs.lib.attrNames moduleToTestsRegex;
+            };
+          in pkgs.lib.listToAttrs (builtins.map (pair: {
+            name = "${pair.module}-${pair.compiler}";
+            value = makeTestDerivation {
+              name = pair.module;
+              compiler = pair.compiler;
+              targets = brokenModuleToTestsNames.${pair.module};
+            };
+          }) compilerBrokenModuleTestsNamesPairs ++ builtins.map (pair: {
+            name = "${pair.module}-${pair.compiler}";
+            value = makeTestDerivation {
+              name = pair.module;
+              compiler = pair.compiler;
+              buildTargets = [ "tests-crypto3-${pair.module}" ];
+              testTargets = [ moduleToTestsRegex.${pair.module} ];
+            };
+          }) compilerModuleTestsRegexPairs);
+      in {
+        packages = rec {
+          crypto3 = (pkgs.callPackage ./crypto3.nix { src_repo = self; });
+          crypto3-debug = (pkgs.callPackage ./crypto3.nix {
+            src_repo = self;
+            enableDebug = true;
+          });
+          default = crypto3;
+        };
+        checks = makeCrypto3Tests { inherit system; };
+      }));
 }
-
 
 # `nix flake -L check .?submodules=1#` to run all tests (-L to output build logs)
 # `nix build -L .?submodules=1#checks.x86_64-linux.hash-clang` for partial testing


### PR DESCRIPTION
This diff introduces the following changes:

- crypto3 derivation moved into a separate file, as per usual Nix guidelines
- enableDebug parameter added to crypto3 to switch debug modes on and off
- enableDebug will build boost with debug symbols
- flake-utils used to enumerate systems (as we do in nix-3rdparty)
- devShells dropped from the toplevel. please use shellHoook in crypto3.nix instead

This is all a set of standard practices to make your life easier and code cleaner.

What still remains is to remove the hardcoding of test sets in the flake.nix. This usually is not recommended to program a lot of logic. The best place to do this would be in a shell script.