### PR TITLE
Fix tests on ci and move slow tests to bench_tests folder.

### DIFF
--- a/libs/hash/test/hash_to_curve.cpp
+++ b/libs/hash/test/hash_to_curve.cpp
@@ -32,7 +32,7 @@
 #include <type_traits>
 #include <tuple>
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 

--- a/libs/marshalling/algebra/test/curve_element.cpp
+++ b/libs/marshalling/algebra/test/curve_element.cpp
@@ -25,7 +25,7 @@
 
 #define BOOST_TEST_MODULE crypto3_marshalling_curve_element_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/random/mersenne_twister.hpp>

--- a/libs/marshalling/zk/test/kzg_commitment.cpp
+++ b/libs/marshalling/zk/test/kzg_commitment.cpp
@@ -28,7 +28,7 @@
 #include "nil/crypto3/zk/commitments/batched_commitment.hpp"
 #define BOOST_TEST_MODULE crypto3_marshalling_kzg_commitment_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <iostream>
 #include <iomanip>

--- a/libs/marshalling/zk/test/lpc_commitment.cpp
+++ b/libs/marshalling/zk/test/lpc_commitment.cpp
@@ -27,7 +27,7 @@
 
 #define BOOST_TEST_MODULE crypto3_marshalling_lpc_commitment_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 
 #include <boost/random/mersenne_twister.hpp>

--- a/libs/marshalling/zk/test/placeholder_common_data.cpp
+++ b/libs/marshalling/zk/test/placeholder_common_data.cpp
@@ -1,6 +1,6 @@
 #define BOOST_TEST_MODULE crypto3_marshalling_placeholder_common_data_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>

--- a/libs/marshalling/zk/test/placeholder_proof.cpp
+++ b/libs/marshalling/zk/test/placeholder_proof.cpp
@@ -27,7 +27,7 @@
 
 #define BOOST_TEST_MODULE crypto3_marshalling_placeholder_proof_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>

--- a/libs/zk/test/CMakeLists.txt
+++ b/libs/zk/test/CMakeLists.txt
@@ -50,7 +50,6 @@ set(TESTS_NAMES
     "commitment/fri"
     "commitment/kzg"
     "commitment/fold_polynomial"
-    "commitment/lpc_performance"
     "commitment/pedersen"
     "commitment/proof_of_knowledge"
 #    "commitment/powers_of_tau"
@@ -110,3 +109,7 @@ endforeach()
 
 # string(CONCAT TEST_DATA ${CMAKE_CURRENT_SOURCE_DIR} "/systems/plonk/pickles/data/kimchi")
 # target_compile_definitions(crypto3_zk_systems_plonk_pickles_kimchi_test PRIVATE TEST_DATA="${TEST_DATA}")
+if(BUILD_BENCH_TESTS)
+    cm_add_test_subdirectory(bench_test)
+endif()
+

--- a/libs/zk/test/bench_test/CMakeLists.txt
+++ b/libs/zk/test/bench_test/CMakeLists.txt
@@ -1,0 +1,45 @@
+#---------------------------------------------------------------------------#
+# Copyright (c) 2018-2021 Mikhail Komarov <nemo@nil.foundation>
+#
+# Distributed under the Boost Software License, Version 1.0
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+#---------------------------------------------------------------------------#
+
+include(CMTest)
+
+add_custom_target(zk_runtime_bench_tests)
+
+macro(define_runtime_zk_test name)
+    set(test_name "zk_${name}_bench_test")
+    add_dependencies(zk_runtime_bench_tests ${test_name})
+
+    cm_test(NAME ${test_name} SOURCES ${name}.cpp)
+
+    target_include_directories(${test_name} PRIVATE
+                               "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                               "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>"
+
+                               ${Boost_INCLUDE_DIRS})
+
+    set_target_properties(${test_name} PROPERTIES CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED TRUE)
+
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        target_compile_options(${test_name} PRIVATE "-fconstexpr-steps=2147483647")
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(${test_name} PRIVATE "-fconstexpr-ops-limit=4294967295")
+    endif()
+
+    target_compile_definitions(${test_name} PRIVATE TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data/")
+endmacro()
+
+set(RUNTIME_TESTS_NAMES
+    "bench_pedersen"
+    "bench_lpc"
+    )
+
+foreach(TEST_NAME ${RUNTIME_TESTS_NAMES})
+    define_runtime_zk_test(${TEST_NAME})
+endforeach()
+

--- a/libs/zk/test/bench_test/lpc.cpp
+++ b/libs/zk/test/bench_test/lpc.cpp
@@ -1,0 +1,400 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2021 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2021 Nikita Kaskov <nbering@nil.foundation>
+// Copyright (c) 2022 Ilia Shirobokov <i.shirobokov@nil.foundation>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE lpc_test
+
+// Do it manually for all performance tests
+#define ZK_PLACEHOLDER_PROFILING_ENABLED
+
+#include <string>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/data/monomorphic.hpp>
+
+#include <nil/crypto3/algebra/curves/bls12.hpp>
+#include <nil/crypto3/algebra/fields/arithmetic_params/bls12.hpp>
+#include <nil/crypto3/algebra/curves/params/multiexp/bls12.hpp>
+#include <nil/crypto3/algebra/curves/params/wnaf/bls12.hpp>
+#include <nil/crypto3/algebra/random_element.hpp>
+
+#include <nil/crypto3/math/algorithms/unity_root.hpp>
+#include <nil/crypto3/math/domains/evaluation_domain.hpp>
+#include <nil/crypto3/math/algorithms/make_evaluation_domain.hpp>
+#include <nil/crypto3/math/algorithms/calculate_domain_set.hpp>
+
+#include <nil/crypto3/zk/commitments/polynomial/lpc.hpp>
+#include <nil/crypto3/zk/commitments/polynomial/fri.hpp>
+#include <nil/crypto3/zk/snark/systems/plonk/placeholder/params.hpp>
+#include <nil/crypto3/zk/snark/systems/plonk/placeholder/detail/placeholder_scoped_profiler.hpp>
+
+using namespace nil::crypto3;
+using namespace nil::crypto3::zk::snark;
+
+namespace boost {
+    namespace test_tools {
+        namespace tt_detail {
+            template<>
+            struct print_log_value<nil::crypto3::math::polynomial<
+                    algebra::fields::detail::element_fp < algebra::fields::params < algebra::fields::bls12_base_field <
+                    381>>>>> {
+            void operator()(std::ostream &,
+                            const nil::crypto3::math::polynomial<algebra::fields::detail::element_fp <
+                                                                 algebra::fields::params <
+                                                                 algebra::fields::bls12_base_field < 381>>
+
+            >> &) {
+        }
+    };
+}    // namespace tt_detail
+}        // namespace test_tools
+}    // namespace boost
+
+template<typename FieldType, typename NumberType>
+std::vector<math::polynomial<typename FieldType::value_type>> generate(NumberType degree) {
+    typedef boost::random::independent_bits_engine<boost::random::mt19937,
+            FieldType::modulus_bits,
+            typename FieldType::value_type::integral_type>
+            random_polynomial_generator_type;
+
+    std::vector<math::polynomial<typename FieldType::value_type>> res;
+
+    boost::random::random_device rd;     // Will be used to obtain a seed for the random number engine
+    boost::random::mt19937 gen(rd());    // Standard mersenne_twister_engine seeded with rd()
+    boost::random::uniform_int_distribution<> distrib(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+
+    random_polynomial_generator_type polynomial_element_gen;
+    std::size_t height = 1;
+    res.reserve(height);
+
+    for (int i = 0; i < height; i++) {
+        math::polynomial<typename FieldType::value_type> poly;
+        for (int j = 0; j < degree; j++) {
+            poly.push_back(typename FieldType::value_type(polynomial_element_gen()));
+        }
+        res.push_back(poly);
+    }
+
+    return res;
+}
+
+inline std::vector<std::size_t> generate_random_step_list(const std::size_t r, const int max_step) {
+    using dist_type = std::uniform_int_distribution<int>;
+    static std::random_device random_engine;
+
+    std::vector<std::size_t> step_list;
+    std::size_t steps_sum = 0;
+    while (steps_sum != r) {
+        if (r - steps_sum <= max_step) {
+            while (r - steps_sum != 1) {
+                step_list.emplace_back(r - steps_sum - 1);
+                steps_sum += step_list.back();
+            }
+            step_list.emplace_back(1);
+            steps_sum += step_list.back();
+        } else {
+            step_list.emplace_back(dist_type(1, max_step)(random_engine));
+            steps_sum += step_list.back();
+        }
+    }
+    return step_list;
+}
+
+BOOST_AUTO_TEST_SUITE(lpc_performance_test_suite)
+
+    BOOST_AUTO_TEST_CASE(step_list_1) {
+        PROFILE_PLACEHOLDER_SCOPE("LPC step list 1 test");
+        typedef algebra::curves::bls12<381> curve_type;
+        typedef typename curve_type::scalar_field_type FieldType;
+
+        typedef hashes::keccak_1600<256> merkle_hash_type;
+        typedef hashes::keccak_1600<256> transcript_hash_type;
+
+        constexpr static const std::size_t lambda = 40;
+        constexpr static const std::size_t k = 1;
+
+        // It's important parameter
+        constexpr static const std::size_t d = 1 << 24;
+        constexpr static const std::size_t r = boost::static_log2<(d - k)>::value;
+
+        constexpr static const std::size_t m = 2;
+
+        typedef zk::commitments::fri<FieldType, merkle_hash_type, transcript_hash_type, m> fri_type;
+        typedef zk::commitments::list_polynomial_commitment_params<merkle_hash_type, transcript_hash_type, m> lpc_params_type;
+        typedef zk::commitments::list_polynomial_commitment<FieldType, lpc_params_type> lpc_type;
+
+        constexpr static const std::size_t d_extended = d;
+        std::size_t extended_log = boost::static_log2<d_extended>::value;
+        std::vector<std::shared_ptr<math::evaluation_domain<FieldType>>> D =
+                math::calculate_domain_set<FieldType>(extended_log, r);
+
+        typename fri_type::params_type fri_params(
+                d - 1,
+                D,
+                generate_random_step_list(r, 1),
+                r,
+                lambda
+        );
+
+        using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, math::polynomial<typename FieldType::value_type>>;
+        lpc_scheme_type lpc_scheme_prover(fri_params);
+        lpc_scheme_type lpc_scheme_verifier(fri_params);
+
+        typedef boost::random::independent_bits_engine<
+                boost::random::mt19937, FieldType::modulus_bits,
+                typename FieldType::value_type::integral_type
+        > random_polynomial_generator_type;
+
+        std::vector<math::polynomial<typename FieldType::value_type>> res;
+
+        // Generate polys
+        boost::random::random_device rd;     // Will be used to obtain a seed for the random number engine
+        boost::random::mt19937 gen(rd());    // Standard mersenne_twister_engine seeded with rd()
+        boost::random::uniform_int_distribution<> distrib(std::numeric_limits<int>::min(),
+                                                          std::numeric_limits<int>::max());
+
+        random_polynomial_generator_type polynomial_element_gen;
+        std::size_t height = 1;
+        res.reserve(height);
+
+        for (int i = 0; i < height; i++) {
+            math::polynomial<typename FieldType::value_type> poly(fri_params.max_degree + 1);
+            for (int j = 0; j < fri_params.max_degree + 1; j++) {
+                poly[i] = typename FieldType::value_type(polynomial_element_gen());
+            }
+
+            std::map<std::size_t, typename lpc_scheme_type::commitment_type> commitments;
+            {
+                PROFILE_PLACEHOLDER_SCOPE("polynomial commitment");
+                lpc_scheme_prover.append_to_batch(0, poly);
+                commitments[0] = lpc_scheme_prover.commit(0);
+            }
+
+
+            typename lpc_scheme_type::proof_type proof;
+            std::array<std::uint8_t, 96> x_data{};
+            {
+                PROFILE_PLACEHOLDER_SCOPE("proof generation");
+                lpc_scheme_prover.append_eval_point(0,
+                                                    algebra::fields::arithmetic_params<FieldType>::multiplicative_generator);
+                zk::transcript::fiat_shamir_heuristic_sequential<transcript_hash_type> transcript(x_data);
+                proof = lpc_scheme_prover.proof_eval(transcript);
+            }
+
+            {
+                PROFILE_PLACEHOLDER_SCOPE("verification");
+                zk::transcript::fiat_shamir_heuristic_sequential<transcript_hash_type> transcript_verifier(x_data);
+                lpc_scheme_verifier.set_batch_size(0, proof.z.get_batch_size(0));
+
+                lpc_scheme_verifier.append_eval_point(0,
+                                                      algebra::fields::arithmetic_params<FieldType>::multiplicative_generator);
+                BOOST_CHECK(lpc_scheme_verifier.verify_eval(proof, commitments, transcript_verifier));
+            }
+        }
+    }
+
+    BOOST_AUTO_TEST_CASE(step_list_3) {
+        PROFILE_PLACEHOLDER_SCOPE("LPC step list 3 test");
+        typedef algebra::curves::bls12<381> curve_type;
+        typedef typename curve_type::scalar_field_type FieldType;
+
+        typedef hashes::keccak_1600<256> merkle_hash_type;
+        typedef hashes::keccak_1600<256> transcript_hash_type;
+
+        constexpr static const std::size_t lambda = 40;
+        constexpr static const std::size_t k = 1;
+
+        // It's important parameter
+        constexpr static const std::size_t d = 1 << 24;
+
+        constexpr static const std::size_t r = boost::static_log2<(d - k)>::value;
+        constexpr static const std::size_t m = 2;
+
+        typedef zk::commitments::fri<FieldType, merkle_hash_type, transcript_hash_type, m> fri_type;
+        typedef zk::commitments::list_polynomial_commitment_params<merkle_hash_type, transcript_hash_type, m> lpc_params_type;
+        typedef zk::commitments::list_polynomial_commitment<FieldType, lpc_params_type> lpc_type;
+
+        constexpr static const std::size_t d_extended = d;
+        std::size_t extended_log = boost::static_log2<d_extended>::value;
+        std::vector<std::shared_ptr<math::evaluation_domain<FieldType>>> D =
+                math::calculate_domain_set<FieldType>(extended_log, r);
+
+        typename fri_type::params_type fri_params(
+                d - 1,
+                D,
+                generate_random_step_list(r, 3),
+                r,
+                lambda
+        );
+
+        using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, math::polynomial<typename FieldType::value_type>>;
+        lpc_scheme_type lpc_scheme_prover(fri_params);
+        lpc_scheme_type lpc_scheme_verifier(fri_params);
+
+        typedef boost::random::independent_bits_engine<
+                boost::random::mt19937, FieldType::modulus_bits,
+                typename FieldType::value_type::integral_type
+        > random_polynomial_generator_type;
+
+        std::vector<math::polynomial<typename FieldType::value_type>> res;
+
+        // Generate polys
+        boost::random::random_device rd;     // Will be used to obtain a seed for the random number engine
+        boost::random::mt19937 gen(rd());    // Standard mersenne_twister_engine seeded with rd()
+        boost::random::uniform_int_distribution<> distrib(std::numeric_limits<int>::min(),
+                                                          std::numeric_limits<int>::max());
+
+        random_polynomial_generator_type polynomial_element_gen;
+        std::size_t height = 1;
+        res.reserve(height);
+
+        for (int i = 0; i < height; i++) {
+            math::polynomial<typename FieldType::value_type> poly(fri_params.max_degree + 1);
+            for (int j = 0; j < fri_params.max_degree + 1; j++) {
+                poly[i] = typename FieldType::value_type(polynomial_element_gen());
+            }
+
+            std::map<std::size_t, typename lpc_scheme_type::commitment_type> commitments;
+            {
+                PROFILE_PLACEHOLDER_SCOPE("polynomial commitment");
+                lpc_scheme_prover.append_to_batch(0, poly);
+                commitments[0] = lpc_scheme_prover.commit(0);
+            }
+
+
+            typename lpc_scheme_type::proof_type proof;
+            std::array<std::uint8_t, 96> x_data{};
+            {
+                PROFILE_PLACEHOLDER_SCOPE("proof generation");
+                lpc_scheme_prover.append_eval_point(0,
+                                                    algebra::fields::arithmetic_params<FieldType>::multiplicative_generator);
+                zk::transcript::fiat_shamir_heuristic_sequential<transcript_hash_type> transcript(x_data);
+                proof = lpc_scheme_prover.proof_eval(transcript);
+            }
+
+            {
+                PROFILE_PLACEHOLDER_SCOPE("verification");
+                zk::transcript::fiat_shamir_heuristic_sequential<transcript_hash_type> transcript_verifier(x_data);
+                lpc_scheme_verifier.set_batch_size(0, proof.z.get_batch_size(0));
+
+                lpc_scheme_verifier.append_eval_point(0,
+                                                      algebra::fields::arithmetic_params<FieldType>::multiplicative_generator);
+                BOOST_CHECK(lpc_scheme_verifier.verify_eval(proof, commitments, transcript_verifier));
+            }
+        }
+    }
+
+    BOOST_AUTO_TEST_CASE(step_list_5) {
+        PROFILE_PLACEHOLDER_SCOPE("LPC step list 5 test");
+        typedef algebra::curves::bls12<381> curve_type;
+        typedef typename curve_type::scalar_field_type FieldType;
+
+        typedef hashes::keccak_1600<256> merkle_hash_type;
+        typedef hashes::keccak_1600<256> transcript_hash_type;
+
+        constexpr static const std::size_t lambda = 40;
+        constexpr static const std::size_t k = 1;
+
+        // It's important parameter
+        constexpr static const std::size_t d = 1 << 24;
+        constexpr static const std::size_t m = 2;
+        constexpr static const std::size_t r = boost::static_log2<(d - k)>::value;
+
+        typedef zk::commitments::fri<FieldType, merkle_hash_type, transcript_hash_type, m> fri_type;
+        typedef zk::commitments::list_polynomial_commitment_params<merkle_hash_type, transcript_hash_type, m> lpc_params_type;
+        typedef zk::commitments::list_polynomial_commitment<FieldType, lpc_params_type> lpc_type;
+
+        constexpr static const std::size_t d_extended = d;
+        std::size_t extended_log = boost::static_log2<d_extended>::value;
+        std::vector<std::shared_ptr<math::evaluation_domain<FieldType>>> D =
+                math::calculate_domain_set<FieldType>(extended_log, r);
+
+        typename fri_type::params_type fri_params(
+                d - 1,
+                D,
+                generate_random_step_list(r, 5),
+                r,
+                lambda
+        );
+
+        using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, math::polynomial<typename FieldType::value_type>>;
+        lpc_scheme_type lpc_scheme_prover(fri_params);
+        lpc_scheme_type lpc_scheme_verifier(fri_params);
+
+        typedef boost::random::independent_bits_engine<
+                boost::random::mt19937, FieldType::modulus_bits,
+                typename FieldType::value_type::integral_type
+        > random_polynomial_generator_type;
+
+        std::vector<math::polynomial<typename FieldType::value_type>> res;
+
+        // Generate polys
+        boost::random::random_device rd;     // Will be used to obtain a seed for the random number engine
+        boost::random::mt19937 gen(rd());    // Standard mersenne_twister_engine seeded with rd()
+        boost::random::uniform_int_distribution<> distrib(std::numeric_limits<int>::min(),
+                                                          std::numeric_limits<int>::max());
+
+        random_polynomial_generator_type polynomial_element_gen;
+        std::size_t height = 1;
+        res.reserve(height);
+
+        for (int i = 0; i < height; i++) {
+            math::polynomial<typename FieldType::value_type> poly(fri_params.max_degree + 1);
+            for (int j = 0; j < fri_params.max_degree + 1; j++) {
+                poly[i] = typename FieldType::value_type(polynomial_element_gen());
+            }
+
+            std::map<std::size_t, typename lpc_scheme_type::commitment_type> commitments;
+            {
+                PROFILE_PLACEHOLDER_SCOPE("polynomial commitment");
+                lpc_scheme_prover.append_to_batch(0, poly);
+                commitments[0] = lpc_scheme_prover.commit(0);
+            }
+
+
+            typename lpc_scheme_type::proof_type proof;
+            std::array<std::uint8_t, 96> x_data{};
+            {
+                PROFILE_PLACEHOLDER_SCOPE("proof generation");
+                lpc_scheme_prover.append_eval_point(0,
+                                                    algebra::fields::arithmetic_params<FieldType>::multiplicative_generator);
+                zk::transcript::fiat_shamir_heuristic_sequential<transcript_hash_type> transcript(x_data);
+                proof = lpc_scheme_prover.proof_eval(transcript);
+            }
+
+            {
+                PROFILE_PLACEHOLDER_SCOPE("verification");
+                zk::transcript::fiat_shamir_heuristic_sequential<transcript_hash_type> transcript_verifier(x_data);
+                lpc_scheme_verifier.set_batch_size(0, proof.z.get_batch_size(0));
+
+                lpc_scheme_verifier.append_eval_point(0,
+                                                      algebra::fields::arithmetic_params<FieldType>::multiplicative_generator);
+                BOOST_CHECK(lpc_scheme_verifier.verify_eval(proof, commitments, transcript_verifier));
+            }
+        }
+    }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libs/zk/test/bench_test/pedersen.cpp
+++ b/libs/zk/test/bench_test/pedersen.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2021 Mikhail Komarov <nemo@nil.foundation>
 // Copyright (c) 2021 Nikita Kaskov <nbering@nil.foundation>
 // Copyright (c) 2022 Ilia Shirobokov <i.shirobokov@nil.foundation>
+// Copyright (c) 2024 Martun Karapetyan <martun@nil.foundation>
 //
 // MIT License
 //
@@ -48,72 +49,15 @@ using namespace nil::crypto3;
 
 BOOST_AUTO_TEST_SUITE(pedersen_test_suite)
 
-BOOST_AUTO_TEST_CASE(pedersen_basic_test) {
+BOOST_AUTO_TEST_CASE(pedersen_long_test) {
 
     // setup
     using curve_type = algebra::curves::bls12<381>;
     using curve_group_type = curve_type::template g1_type<>;
     using field_type = typename curve_type::scalar_field_type;
 
-    constexpr static const int n = 50;
-    constexpr static const int k = 26;
-    curve_group_type::value_type g = algebra::random_element<curve_group_type>();
-    curve_group_type::value_type h = algebra::random_element<curve_group_type>();
-    while (g == h) {
-        h = algebra::random_element<curve_group_type>();
-    }
-
-    typedef typename zk::commitments::pedersen<curve_type> pedersen_type;
-
-    typedef typename pedersen_type::proof_type proof_type;
-    typedef typename pedersen_type::params_type params_type;
-
-    params_type params;
-
-    params.n = n;
-    params.k = k;
-    params.g = g;
-    params.h = h;
-
-    BOOST_CHECK(g != h);
-    BOOST_CHECK(n >= k);
-    BOOST_CHECK(k > 0);
-
-    // commit
-    constexpr static const field_type::value_type w = field_type::value_type(37684);
-
-    // eval
-    proof_type proof = pedersen_type::proof_eval(params, w);
-
-    // verify
-    BOOST_CHECK(pedersen_type::verify_eval(params, proof));
-
-    std::vector<int> idx;
-    std::vector<int> idx_base;
-    for (int i = 1; i <= n; ++i) {
-        idx_base.push_back(i);
-    }
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::shuffle(idx_base.begin(), idx_base.end(), gen);
-    for (int i = 0; i < k; ++i) {
-        idx.push_back(idx_base[i]);
-    }
-
-    BOOST_CHECK(idx.size() >= k);
-    field_type::value_type secret = pedersen_type::message_eval(params, proof, idx);
-    BOOST_CHECK(w == secret);
-}
-
-BOOST_AUTO_TEST_CASE(pedersen_short_test) {
-
-    // setup
-    using curve_type = algebra::curves::bls12<381>;
-    using curve_group_type = curve_type::template g1_type<>;
-    using field_type = typename curve_type::scalar_field_type;
-
-    constexpr static const int n = 2;
-    constexpr static const int k = 1;
+    constexpr static const int n = 2000000000;
+    constexpr static const int k = 1999999999;
     static curve_group_type::value_type g = algebra::random_element<curve_group_type>();
     static curve_group_type::value_type h = algebra::random_element<curve_group_type>();
     while (g == h) {
@@ -137,7 +81,7 @@ BOOST_AUTO_TEST_CASE(pedersen_short_test) {
     BOOST_CHECK(k > 0);
 
     // commit
-    constexpr static const field_type::value_type w = field_type::value_type(3);
+    constexpr static const field_type::value_type w = field_type::value_type(300000000);
 
     // eval
     proof_type proof = pedersen_type::proof_eval(params, w);

--- a/libs/zk/test/commitment/kzg.cpp
+++ b/libs/zk/test/commitment/kzg.cpp
@@ -29,7 +29,7 @@
 
 #include <string>
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 

--- a/libs/zk/test/systems/plonk/placeholder/placeholder_circuits.cpp
+++ b/libs/zk/test/systems/plonk/placeholder/placeholder_circuits.cpp
@@ -32,7 +32,7 @@
 
 #define BOOST_TEST_MODULE placeholder_circuits_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 
 #include <nil/crypto3/hash/algorithm/hash.hpp>

--- a/libs/zk/test/systems/plonk/placeholder/placeholder_curves.cpp
+++ b/libs/zk/test/systems/plonk/placeholder/placeholder_curves.cpp
@@ -32,7 +32,7 @@
 
 #define BOOST_TEST_MODULE placeholder_curves_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 

--- a/libs/zk/test/systems/plonk/placeholder/placeholder_gate_argument.cpp
+++ b/libs/zk/test/systems/plonk/placeholder/placeholder_gate_argument.cpp
@@ -31,7 +31,7 @@
 
 #define BOOST_TEST_MODULE placeholder_gate_argument_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 

--- a/libs/zk/test/systems/plonk/placeholder/placeholder_goldilocks.cpp
+++ b/libs/zk/test/systems/plonk/placeholder/placeholder_goldilocks.cpp
@@ -32,7 +32,7 @@
 
 #define BOOST_TEST_MODULE placeholder_goldilocks_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 
 #include <nil/crypto3/algebra/fields/goldilocks64/base_field.hpp>

--- a/libs/zk/test/systems/plonk/placeholder/placeholder_hashes.cpp
+++ b/libs/zk/test/systems/plonk/placeholder/placeholder_hashes.cpp
@@ -32,7 +32,7 @@
 
 #define BOOST_TEST_MODULE placeholder_hashes_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 

--- a/libs/zk/test/systems/plonk/placeholder/placeholder_kzg.cpp
+++ b/libs/zk/test/systems/plonk/placeholder/placeholder_kzg.cpp
@@ -32,7 +32,7 @@
 
 #define BOOST_TEST_MODULE placeholder_kzg_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 
 #include <nil/crypto3/algebra/curves/mnt4.hpp>

--- a/libs/zk/test/systems/plonk/placeholder/placeholder_lookup_argument.cpp
+++ b/libs/zk/test/systems/plonk/placeholder/placeholder_lookup_argument.cpp
@@ -31,7 +31,7 @@
 
 #define BOOST_TEST_MODULE placeholder_lookup_argument_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 
 #include <nil/crypto3/algebra/curves/pallas.hpp>

--- a/libs/zk/test/systems/plonk/placeholder/placeholder_permutation_argument.cpp
+++ b/libs/zk/test/systems/plonk/placeholder/placeholder_permutation_argument.cpp
@@ -32,7 +32,7 @@
 
 #define BOOST_TEST_MODULE placeholder_permutation_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/data/monomorphic.hpp>
 

--- a/libs/zk/test/systems/plonk/placeholder/placeholder_quotient_polynomial_chunks.cpp
+++ b/libs/zk/test/systems/plonk/placeholder/placeholder_quotient_polynomial_chunks.cpp
@@ -32,7 +32,7 @@
 
 #define BOOST_TEST_MODULE placeholder_quotient_polynomial_chunks_test
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 
 #include <nil/crypto3/algebra/curves/pallas.hpp>


### PR DESCRIPTION
- Changed boost unit tests include path, for some reason the path with /included results to segfault on the ci.
- Moved all slow tests to bench_test folder. They must have been there in the first place.