### PR TITLE
Convert to the required integral type when multiplying a scalar with a curve point.

### DIFF
--- a/libs/algebra/include/nil/crypto3/algebra/curves/detail/scalar_mul.hpp
+++ b/libs/algebra/include/nil/crypto3/algebra/curves/detail/scalar_mul.hpp
@@ -174,7 +174,10 @@ namespace nil {
                                             GroupValueType>::type
                         operator*(const GroupValueType &left, const FieldValueType &right) {
 
-                        return left * static_cast<typename GroupValueType::params_type::scalar_field_type::integral_type>(right.data);
+                        // TODO(martun): consider deleting this function, and forcing all the callers to convert to the
+                        // required type before multiplication.
+                        return left * static_cast<typename GroupValueType::params_type::scalar_field_type::integral_type>(
+                            typename FieldValueType::integral_type(right.data));
                     }
 
                     template<typename GroupValueType, typename FieldValueType>


### PR DESCRIPTION
When multiplying an EC curve point to a scalar value, the scalar must be integral_type, not value_type, and it must be of the same bit-length as the group used for EC scalar values. The caller must convert it to the corrent integral type before multiplying.

Yet we have lots of use cases mostly in blueprint where an integral_type number of different field is multiplied by and EC point. In these cases we will convert them in algebra itself, for now. Later we may consider moving this conversions to the callers and deleting this operator*.